### PR TITLE
Adding unit tests for the existing API

### DIFF
--- a/src/corerestclient/RestClient.cs
+++ b/src/corerestclient/RestClient.cs
@@ -11,7 +11,7 @@ namespace corerestclient
 		private string authType;
         private string contentType;
         private bool hasAuth;
-        private HttpClient client = new HttpClient();
+        private HttpClient client;
         
         private HttpClient Client
         {
@@ -35,36 +35,40 @@ namespace corerestclient
             }
         }
 
-        public RestClient()
+        public RestClient(HttpMessageHandler handler = null)
         {
             this.hasAuth = false;
-            this.contentType = "application/json";
+            this.contentType = "application/json";            
+            this.client = handler != null ? new HttpClient(handler) : new HttpClient();
         }
 
-        public RestClient(string basicAuthToken)
+        public RestClient(string basicAuthToken, HttpMessageHandler handler = null)
         {
             this.hasAuth = true;
             this.authToken = basicAuthToken;
             this.contentType = "application/json";
+            this.client = handler != null ? new HttpClient(handler) : new HttpClient();
         }
 
-        public RestClient(string basicAuthToken, string contentType)
+        public RestClient(string basicAuthToken, string contentType, HttpMessageHandler handler = null)
         {
             this.hasAuth = true;
             this.authToken = basicAuthToken;
             this.contentType = contentType;
+            this.client = handler != null ? new HttpClient(handler) : new HttpClient();
         }
 
         /* Adds generic constructor for multiple auth types like Bearer Basic etc. 
          * OAuth/JWT example : Authorization : Bearer <TOKEN>
          * Basic example : Authorization : Basic <TOKEN> 
          */
-        public RestClient(string authType, string authToken, string contentType)
+        public RestClient(string authType, string authToken, string contentType, HttpMessageHandler handler = null)
         {
             this.hasAuth = true;
             this.authType = authType;
             this.authToken = authToken;
             this.contentType = contentType;
+            this.client = handler != null ? new HttpClient(handler) : new HttpClient();
         }
 
         public string Post(string uri, string body)
@@ -81,7 +85,7 @@ namespace corerestclient
 
         public string Patch(string uri, string body)
         {
-            var method = new HttpMethod("PATCH");
+            var method = new HttpMethod("PATCH");            
             var request = new HttpRequestMessage(method, uri) { Content = new StringContent(body, Encoding.UTF8, this.contentType) };
                 
             var response = Client.SendAsync(request).Result;

--- a/test/corerestclient.tests/Tests.cs
+++ b/test/corerestclient.tests/Tests.cs
@@ -1,6 +1,11 @@
 ﻿using System;
 using Xunit;
 using corerestclient;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net;
+using RichardSzalay.MockHttp;
 
 namespace corerestclient.Tests
 {
@@ -12,6 +17,313 @@ namespace corerestclient.Tests
             var client = new corerestclient.RestClient();
             var result = client.Get("https://api.stackexchange.com/2.2/questions?page=1&pagesize=1&order=desc&sort=activity&site=stackoverflow");
             Assert.False(string.IsNullOrEmpty(result));
+        }
+
+        [Fact]
+        public void TestMockedGet() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Get, "http://127.0.0.1")
+                .WithHeaders("Accept", "application/json")
+                .Respond("text/plain", "GET OK");            
+            var client = new corerestclient.RestClient(mockHandler);
+            var result = client.Get("http://127.0.0.1");
+            Assert.True(result.Contains("GET OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPost() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Post, "http://127.0.0.1")
+                .WithHeaders("Accept", "application/json")
+                .WithContent("POST CONTENT")
+                .Respond("text/plain", "POST OK");            
+            var client = new corerestclient.RestClient(mockHandler);
+            var result = client.Post("http://127.0.0.1", "POST CONTENT");
+            Assert.True(result.Contains("POST OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPut() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Put, "http://127.0.0.1/testResource")
+                .WithHeaders("Accept", "application/json")
+                .WithContent("PUT CONTENT")
+                .Respond("text/plain", "PUT OK");            
+            var client = new corerestclient.RestClient(mockHandler);
+            var result = client.Put("http://127.0.0.1", "testResource", "PUT CONTENT");
+            Assert.True(result.Contains("PUT OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedDelete() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Delete, "http://127.0.0.1")   
+                .WithHeaders("Accept", "application/json")             
+                .Respond("text/plain", "DELETE OK");            
+            var client = new corerestclient.RestClient(mockHandler);
+            var result = client.Delete("http://127.0.0.1");
+            Assert.True(result.Contains("DELETE OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPatch() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect("http://127.0.0.1")
+                .WithHeaders("Accept", "application/json")
+                .WithContent("PATCH CONTENT")
+                .Respond("text/plain", "PATCH OK");            
+            var client = new corerestclient.RestClient(mockHandler);
+            var result = client.Patch("http://127.0.0.1", "PATCH CONTENT");
+            Assert.True(result.Contains("PATCH OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedGetWithAuth() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Get, "http://127.0.0.1")
+                .WithHeaders("Accept", "application/json")
+                .WithHeaders("Authorization", "basicAuthToken")              
+                .Respond("text/plain", "GET OK");            
+            var client = new corerestclient.RestClient("basicAuthToken", mockHandler);
+            var result = client.Get("http://127.0.0.1");
+            Assert.True(result.Contains("GET OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPostWithAuth() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Post, "http://127.0.0.1")
+                .WithHeaders("Accept", "application/json")
+                .WithHeaders("Authorization", "basicAuthToken")
+                .WithContent("POST CONTENT")
+                .Respond("text/plain", "POST OK");            
+            var client = new corerestclient.RestClient("basicAuthToken", mockHandler);
+            var result = client.Post("http://127.0.0.1", "POST CONTENT");
+            Assert.True(result.Contains("POST OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPutWithAuth() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Put, "http://127.0.0.1/testResource")
+                .WithHeaders("Accept", "application/json")
+                .WithHeaders("Authorization", "basicAuthToken")
+                .WithContent("PUT CONTENT")
+                .Respond("text/plain", "PUT OK");            
+            var client = new corerestclient.RestClient("basicAuthToken", mockHandler);
+            var result = client.Put("http://127.0.0.1", "testResource", "PUT CONTENT");
+            Assert.True(result.Contains("PUT OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedDeleteWithAuth() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Delete, "http://127.0.0.1") 
+                .WithHeaders("Accept", "application/json")
+                .WithHeaders("Authorization", "basicAuthToken")               
+                .Respond("text/plain", "DELETE OK");            
+            var client = new corerestclient.RestClient("basicAuthToken", mockHandler);
+            var result = client.Delete("http://127.0.0.1");
+            Assert.True(result.Contains("DELETE OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPatchWithAuth() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect("http://127.0.0.1")
+                .WithHeaders("Accept", "application/json")
+                .WithHeaders("Authorization", "basicAuthToken")
+                .WithContent("PATCH CONTENT")
+                .Respond("text/plain", "PATCH OK");            
+            var client = new corerestclient.RestClient("basicAuthToken", mockHandler);
+            var result = client.Patch("http://127.0.0.1", "PATCH CONTENT");
+            Assert.True(result.Contains("PATCH OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedGetWithAuthAndContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Get, "http://127.0.0.1")
+                .WithHeaders("Accept", "text/plain")
+                .WithHeaders("Authorization", "basicAuthToken")              
+                .Respond("text/plain", "GET OK");            
+            var client = new corerestclient.RestClient("basicAuthToken", "text/plain", mockHandler);
+            var result = client.Get("http://127.0.0.1");
+            Assert.True(result.Contains("GET OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPostWithAuthAndContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Post, "http://127.0.0.1")
+                .WithHeaders("Accept", "text/plain")
+                .WithHeaders("Authorization", "basicAuthToken")
+                .WithContent("POST CONTENT")
+                .Respond("text/plain", "POST OK");            
+            var client = new corerestclient.RestClient("basicAuthToken", "text/plain", mockHandler);
+            var result = client.Post("http://127.0.0.1", "POST CONTENT");
+            Assert.True(result.Contains("POST OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPutWithAuthAndContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Put, "http://127.0.0.1/testResource")
+                .WithHeaders("Accept", "text/plain")
+                .WithHeaders("Authorization", "basicAuthToken")
+                .WithContent("PUT CONTENT")
+                .Respond("text/plain", "PUT OK");            
+            var client = new corerestclient.RestClient("basicAuthToken", "text/plain", mockHandler);
+            var result = client.Put("http://127.0.0.1", "testResource", "PUT CONTENT");
+            Assert.True(result.Contains("PUT OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedDeleteWithAuthAndContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Delete, "http://127.0.0.1") 
+                .WithHeaders("Accept", "text/plain")
+                .WithHeaders("Authorization", "basicAuthToken")               
+                .Respond("text/plain", "DELETE OK");            
+            var client = new corerestclient.RestClient("basicAuthToken", "text/plain", mockHandler);
+            var result = client.Delete("http://127.0.0.1");
+            Assert.True(result.Contains("DELETE OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPatchWithAuthAndContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect("http://127.0.0.1")
+                .WithHeaders("Accept", "text/plain")
+                .WithHeaders("Authorization", "basicAuthToken")
+                .WithContent("PATCH CONTENT")
+                .Respond("text/plain", "PATCH OK");            
+            var client = new corerestclient.RestClient("basicAuthToken", "text/plain", mockHandler);
+            var result = client.Patch("http://127.0.0.1", "PATCH CONTENT");
+            Assert.True(result.Contains("PATCH OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedGetWithOtherAuthAndContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Get, "http://127.0.0.1")
+                .WithHeaders("Accept", "text/plain")
+                .WithHeaders("Authorization", "Basic basicAuthUser:basicAuthPassword")              
+                .Respond("text/plain", "GET OK");            
+            var client = new corerestclient.RestClient("Basic", "basicAuthUser:basicAuthPassword", "text/plain", mockHandler);
+            var result = client.Get("http://127.0.0.1");
+            Assert.True(result.Contains("GET OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPostWithOtherAuthAndContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Post, "http://127.0.0.1")
+                .WithHeaders("Accept", "text/plain")
+                .WithHeaders("Authorization", "Basic basicAuthUser:basicAuthPassword")
+                .WithContent("POST CONTENT")
+                .Respond("text/plain", "POST OK");            
+            var client = new corerestclient.RestClient("Basic", "basicAuthUser:basicAuthPassword", "text/plain", mockHandler);
+            var result = client.Post("http://127.0.0.1", "POST CONTENT");
+            Assert.True(result.Contains("POST OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPutWithOtherAuthAndContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Put, "http://127.0.0.1/testResource")
+                .WithHeaders("Accept", "text/plain")
+                .WithHeaders("Authorization", "Basic basicAuthUser:basicAuthPassword")
+                .WithContent("PUT CONTENT")
+                .Respond("text/plain", "PUT OK");            
+            var client = new corerestclient.RestClient("Basic", "basicAuthUser:basicAuthPassword", "text/plain", mockHandler);
+            var result = client.Put("http://127.0.0.1", "testResource", "PUT CONTENT");
+            Assert.True(result.Contains("PUT OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedDeleteWithOtherAuthAndContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Delete, "http://127.0.0.1") 
+                .WithHeaders("Accept", "text/plain")
+                .WithHeaders("Authorization", "Basic basicAuthUser:basicAuthPassword")               
+                .Respond("text/plain", "DELETE OK");            
+            var client = new corerestclient.RestClient("Basic", "basicAuthUser:basicAuthPassword", "text/plain", mockHandler);
+            var result = client.Delete("http://127.0.0.1");
+            Assert.True(result.Contains("DELETE OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPatchWithOtherAuthAndContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect("http://127.0.0.1")
+                .WithHeaders("Accept", "text/plain")
+                .WithHeaders("Authorization", "Basic basicAuthUser:basicAuthPassword")
+                .WithContent("PATCH CONTENT")
+                .Respond("text/plain", "PATCH OK");            
+            var client = new corerestclient.RestClient("Basic", "basicAuthUser:basicAuthPassword", "text/plain", mockHandler);
+            var result = client.Patch("http://127.0.0.1", "PATCH CONTENT");
+            Assert.True(result.Contains("PATCH OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
         }
     }
 }

--- a/test/corerestclient.tests/project.json
+++ b/test/corerestclient.tests/project.json
@@ -7,6 +7,7 @@
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
+    "RichardSzalay.MockHttp": "3.0.0",
     "corerestclient": {
       "target": "project"
     }


### PR DESCRIPTION
Adding a more complete suite of unit tests for issue #9. This did require a tiny bit of modification to the rest client itself to allow for the injection of a mocked `HttpMessageHandler`. The two PUT tests will not pass until PR #14 is accepted.