### PR TITLE
Setting content type to be a public property

### DIFF
--- a/src/corerestclient/RestClient.cs
+++ b/src/corerestclient/RestClient.cs
@@ -9,7 +9,7 @@ namespace corerestclient
     {
         private string authToken;
 		private string authType;
-        private string contentType;
+        public string contentType {get; set;}
         private bool hasAuth;
         private HttpClient client;
         

--- a/test/corerestclient.tests/Tests.cs
+++ b/test/corerestclient.tests/Tests.cs
@@ -325,5 +325,83 @@ namespace corerestclient.Tests
             Assert.True(result.Contains("PATCH OK"));
             mockHandler.VerifyNoOutstandingExpectation();
         }
-    }
+
+        [Fact]
+        public void TestMockedGetContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Get, "http://127.0.0.1")
+                .WithHeaders("Accept", "text/plain")
+                .Respond("text/plain", "GET OK");            
+            var client = new corerestclient.RestClient(mockHandler);
+            client.contentType = "text/plain";
+            var result = client.Get("http://127.0.0.1");
+            Assert.True(result.Contains("GET OK"));            
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPostContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Post, "http://127.0.0.1")
+                .WithHeaders("Accept", "text/plain")
+                .WithContent("POST CONTENT")
+                .Respond("text/plain", "POST OK");            
+            var client = new corerestclient.RestClient(mockHandler);
+            client.contentType = "text/plain";
+            var result = client.Post("http://127.0.0.1", "POST CONTENT");
+            Assert.True(result.Contains("POST OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPutContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Put, "http://127.0.0.1/testResource")
+                .WithHeaders("Accept", "text/plain")
+                .WithContent("PUT CONTENT")
+                .Respond("text/plain", "PUT OK");            
+            var client = new corerestclient.RestClient(mockHandler);
+            client.contentType = "text/plain";
+            var result = client.Put("http://127.0.0.1", "testResource", "PUT CONTENT");
+            Assert.True(result.Contains("PUT OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedDeleteContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect(HttpMethod.Delete, "http://127.0.0.1")   
+                .WithHeaders("Accept", "text/plain")           
+                .Respond("text/plain", "DELETE OK");            
+            var client = new corerestclient.RestClient(mockHandler);
+            client.contentType = "text/plain";
+            var result = client.Delete("http://127.0.0.1");
+            Assert.True(result.Contains("DELETE OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public void TestMockedPatchContentType() 
+        {
+            var mockHandler = new MockHttpMessageHandler();     
+            mockHandler
+                .Expect("http://127.0.0.1")
+                .WithHeaders("Accept", "text/plain")
+                .WithContent("PATCH CONTENT")
+                .Respond("text/plain", "PATCH OK");            
+            var client = new corerestclient.RestClient(mockHandler);
+            client.contentType = "text/plain";
+            var result = client.Patch("http://127.0.0.1", "PATCH CONTENT");
+            Assert.True(result.Contains("PATCH OK"));
+            mockHandler.VerifyNoOutstandingExpectation();
+        }
+    }    
 }


### PR DESCRIPTION
This is intended to implement the enhancement detailed in issue #16. There are other ways to go about adding this, but making the contentType property public is definitely the simplest approach which doesn't break the existing API. Since `basicAuthToken` and `contentType` are both strings, it's difficult to create another constructor overload.

I'm certainly open to input if anyone thinks that this should be done in a different way. I'm in no way implying that the way I've done it is the only or the best method, it just seemed to be ideal to avoid an API breaking change.
